### PR TITLE
Fix compatibility with new llvm-mos

### DIFF
--- a/ca65src/ggsound.asm
+++ b/ca65src/ggsound.asm
@@ -11,8 +11,8 @@
     pha
     lda sound_bank
     jsr set_prg_bank
-    jsr .loword(sound_update)
-    jsr .loword(sound_upload)
+    jsr sound_update
+    jsr sound_upload
     pla
     jsr set_prg_bank
 sound_update_disabled:
@@ -203,10 +203,10 @@ done:
     sta apu_dpcm_state
     .endif
 
-    jsr .loword(sound_initialize_apu_buffer)
+    jsr sound_initialize_apu_buffer
 
     ;Make sure all streams are killed.
-    jsr .loword(sound_stop)
+    jsr sound_stop
 
     dec sound_disable_update
 
@@ -233,7 +233,7 @@ loop:
     dex
     bpl loop
 
-    jsr .loword(sound_initialize_apu_buffer)
+    jsr sound_initialize_apu_buffer
 
     dec sound_disable_update
 
@@ -273,7 +273,7 @@ song_stream_register_copy_loop:
     beq song_stream_not_active
 
     ;Update the stream.
-    jsr .loword(stream_update)
+    jsr stream_update
 
     ;Load channel number.
     lda stream_channel,x
@@ -306,7 +306,7 @@ sfx_stream_register_copy_loop:
     beq sfx_stream_not_active
 
     ;Update the stream.
-    jsr .loword(stream_update)
+    jsr stream_update
 
     ;Load channel number
     lda stream_channel,x
@@ -500,9 +500,9 @@ arpeggio_callback_table_hi:
     pha
     lda #<(return_from_arpeggio_callback-1)
     pha
-    lda .loword(arpeggio_callback_table_hi),y
+    lda arpeggio_callback_table_hi,y
     pha
-    lda .loword(arpeggio_callback_table_lo),y
+    lda arpeggio_callback_table_lo,y
     pha
     rts
 return_from_arpeggio_callback:
@@ -686,9 +686,9 @@ square_2_play_note = square_1_play_note
     pha
     lda #<(return_from_arpeggio_callback-1)
     pha
-    lda .loword(arpeggio_callback_table_hi),y
+    lda arpeggio_callback_table_hi,y
     pha
-    lda .loword(arpeggio_callback_table_lo),y
+    lda arpeggio_callback_table_lo,y
     pha
     rts
 return_from_arpeggio_callback:
@@ -818,9 +818,9 @@ pitch_stop:
     pha
     lda #<(return_from_arpeggio_callback-1)
     pha
-    lda .loword(arpeggio_callback_table_hi),y
+    lda arpeggio_callback_table_hi,y
     pha
-    lda .loword(arpeggio_callback_table_lo),y
+    lda arpeggio_callback_table_lo,y
     pha
     rts
 return_from_arpeggio_callback:
@@ -1418,7 +1418,7 @@ not_sound_effect:
 
     ;Select header tempo offset based on region.
     ldx sound_region
-    lda .loword(sound_region_to_tempo_offset),x
+    lda sound_region_to_tempo_offset,x
     sta sound_local_byte_0
 
     ;Get song address from song list.
@@ -1433,7 +1433,7 @@ not_sound_effect:
 
     ;Load square 1 stream.
     ldx #0
-    jsr .loword(stream_stop)
+    jsr stream_stop
 
     ldy #track_header_square1_stream_address
     lda (song_address),y
@@ -1449,7 +1449,7 @@ not_sound_effect:
     lda #0
     sta sound_param_byte_1
 
-    jsr .loword(stream_initialize)
+    jsr stream_initialize
 
     clc
     lda #track_header_ntsc_tempo_lo
@@ -1467,7 +1467,7 @@ no_square_1:
 
     ;Load square 2 stream.
     ldx #1
-    jsr .loword(stream_stop)
+    jsr stream_stop
 
     ldy #track_header_square2_stream_address
     lda (song_address),y
@@ -1483,7 +1483,7 @@ no_square_1:
     lda #1
     sta sound_param_byte_1
 
-    jsr .loword(stream_initialize)
+    jsr stream_initialize
 
     clc
     lda #track_header_ntsc_tempo_lo
@@ -1501,7 +1501,7 @@ no_square_2:
 
     ;Load triangle stream.
     ldx #2
-    jsr .loword(stream_stop)
+    jsr stream_stop
 
     ldy #track_header_triangle_stream_address
     lda (song_address),y
@@ -1517,7 +1517,7 @@ no_square_2:
     lda #2
     sta sound_param_byte_1
 
-    jsr .loword(stream_initialize)
+    jsr stream_initialize
 
     clc
     lda #track_header_ntsc_tempo_lo
@@ -1535,7 +1535,7 @@ no_triangle:
 
     ;Load noise stream.
     ldx #3
-    jsr .loword(stream_stop)
+    jsr stream_stop
 
     ldy #track_header_noise_stream_address
     lda (song_address),y
@@ -1551,7 +1551,7 @@ no_triangle:
     lda #3
     sta sound_param_byte_1
 
-    jsr .loword(stream_initialize)
+    jsr stream_initialize
 
     clc
     lda #track_header_ntsc_tempo_lo
@@ -1570,7 +1570,7 @@ no_noise:
     .ifdef FEATURE_DPCM
     ;Load dpcm stream.
     ldx #4
-    jsr .loword(stream_stop)
+    jsr stream_stop
 
     ldy #track_header_dpcm_stream_address
     lda (song_address),y
@@ -1586,7 +1586,7 @@ no_noise:
     lda #4
     sta sound_param_byte_1
 
-    jsr .loword(stream_initialize)
+    jsr stream_initialize
 
     lda #DPCM_STATE_NOP
     sta apu_dpcm_state
@@ -1640,7 +1640,7 @@ no_dpcm:
 
     ;Select header tempo offset based on region.
     ldx sound_region
-    lda .loword(sound_region_to_tempo_offset),x
+    lda sound_region_to_tempo_offset,x
     sta sound_local_byte_1
 
     ;Get sfx address from sfx list.
@@ -1671,7 +1671,7 @@ no_dpcm:
     lda sound_local_byte_0
     sta sound_param_byte_1
 
-    jsr .loword(stream_initialize)
+    jsr stream_initialize
 
     ldx sound_local_byte_0
     clc
@@ -1710,7 +1710,7 @@ skip0:
     lda sound_local_byte_0
     sta sound_param_byte_1
 
-    jsr .loword(stream_initialize)
+    jsr stream_initialize
 
     ldx sound_local_byte_0
     clc
@@ -1749,7 +1749,7 @@ skip1:
     lda sound_local_byte_0
     sta sound_param_byte_1
 
-    jsr .loword(stream_initialize)
+    jsr stream_initialize
 
     ldx sound_local_byte_0
     clc
@@ -1786,7 +1786,7 @@ no_triangle:
     lda sound_local_byte_0
     sta sound_param_byte_1
 
-    jsr .loword(stream_initialize)
+    jsr stream_initialize
 
     ldx sound_local_byte_0
     clc
@@ -1820,7 +1820,7 @@ no_noise:
     lda sound_local_byte_0
     sta sound_param_byte_1
 
-    jsr .loword(stream_initialize)
+    jsr stream_initialize
 
     ldx sound_local_byte_0
     clc
@@ -2023,12 +2023,12 @@ process_opcode:
     sbc #OPCODES_BASE
     tay
     ;Get the address.
-    lda .loword(stream_callback_table_lo),y
+    lda stream_callback_table_lo,y
     sta callback_address
-    lda .loword(stream_callback_table_hi),y
+    lda stream_callback_table_hi,y
     sta callback_address+1
     ;Call the callback!
-    jsr .loword(indirect_jsr_callback_address)
+    jsr indirect_jsr_callback_address
 
     ;Advance the stream's read address.
     advance_stream_read_address
@@ -2040,20 +2040,20 @@ process_opcode:
     ;control opcode "terminate" work? It works by pulling the current return
     ;address off the stack and then performing an rts, effectively returning
     ;from its caller, this routine.
-    jmp .loword(stream_update)
+    jmp stream_update
 
 process_note:
 
     ;Determine which channel callback to use.
     lda stream_channel,x
     tay
-    lda .loword(channel_callback_table_lo),y
+    lda channel_callback_table_lo,y
     sta callback_address
-    lda .loword(channel_callback_table_hi),y
+    lda channel_callback_table_hi,y
     sta callback_address+1
 
     ;Call the channel callback!
-    jsr .loword(indirect_jsr_callback_address)
+    jsr indirect_jsr_callback_address
 
     sec
     lda stream_tempo_counter_lo,x
@@ -2234,7 +2234,7 @@ note_length_counter_not_zero:
     lda apu_data_ready
     beq apu_data_not_ready
 
-    jsr .loword(sound_upload_apu_register_sets)
+    jsr sound_upload_apu_register_sets
 
 apu_data_not_ready:
 
@@ -2301,18 +2301,18 @@ noise:
     ;a DPCM sound effect to override the currenty playing music DPCM sample until finished.
 dpcm:
     ldx apu_dpcm_state
-    lda .loword(dpcm_state_callback_hi),x
+    lda dpcm_state_callback_hi,x
     pha
-    lda .loword(dpcm_state_callback_lo),x
+    lda dpcm_state_callback_lo,x
     pha
     rts
 dpcm_upload:
-    jsr .loword(dpcm_upload_registers)
+    jsr dpcm_upload_registers
     lda #DPCM_STATE_NOP
     sta apu_dpcm_state
     rts
 dpcm_upload_then_wait:
-    jsr .loword(dpcm_upload_registers)
+    jsr dpcm_upload_registers
     lda #DPCM_STATE_WAIT
     sta apu_dpcm_state
     rts

--- a/src/bank-helper.hpp
+++ b/src/bank-helper.hpp
@@ -3,12 +3,6 @@
 #include "common.hpp"
 #include <mapper.h>
 #include <type_traits>
-#define GET_BANK(symbol)                                                       \
-  []() {                                                                       \
-    register u8 bank asm("a");                                                 \
-    asm("ld%0 #mos24bank(" #symbol ")\n" : "=r"(bank) : "r"(bank));            \
-    return bank;                                                               \
-  }()
 
 class ScopedBank {
   u8 old_bank;

--- a/src/banked-asset-helpers.cpp
+++ b/src/banked-asset-helpers.cpp
@@ -13,12 +13,12 @@
 #pragma clang section rodata = ".prg_rom_fixed.rodata.bah"
 
 void banked_play_song(Song song) {
-  ScopedBank scoopedBank(GET_BANK(song_list));
+  ScopedBank scoopedBank(GGSound::BANK);
   GGSound::play_song(song);
 }
 
 void banked_play_sfx(SFX sfx, GGSound::SFXPriority priority) {
-  ScopedBank scopedBank(GET_BANK(sfx_list));
+  ScopedBank scopedBank(GGSound::BANK);
   GGSound::play_sfx(sfx, priority);
 }
 

--- a/src/ggsound.cpp
+++ b/src/ggsound.cpp
@@ -26,11 +26,12 @@ namespace GGSound {
   __attribute__((noinline)) void init(Region arg_region,
                                       const Track *arg_song_list[],
                                       const Track *arg_sfx_list[],
-                                      const void *arg_instruments[],
+                                      const void *arg_instruments[]
 #ifdef FEATURE_DPCM
-                                      const void *dpcm_pointers[],
+                                      ,
+                                      const void *dpcm_pointers[]
 #endif
-                                      u8 arg_bank) {
+  ) {
     sound_param_byte_0 = (u8)arg_region;
     sound_param_word_0 = (void *)arg_song_list;
     sound_param_word_1 = (void *)arg_sfx_list;
@@ -38,7 +39,7 @@ namespace GGSound {
 #ifdef FEATURE_DPCM
     sound_param_word_3 = (void *)dpcm_pointers;
 #endif
-    sound_bank = arg_bank;
+    sound_bank = BANK;
     ScopedBank ggsound_bank(BANK);
     sound_initialize();
   }

--- a/src/ggsound.cpp
+++ b/src/ggsound.cpp
@@ -14,8 +14,6 @@ extern "C" void *sound_param_word_3;
 extern "C" u8 sound_bank;
 
 namespace GGSound {
-  constexpr u8 BANK = 2;
-
   inline namespace Wrapper {
     extern "C" void sound_initialize();
     extern "C" void sound_stop();

--- a/src/ggsound.hpp
+++ b/src/ggsound.hpp
@@ -6,6 +6,8 @@
 // #define FEATURE_DPCM
 
 namespace GGSound {
+  constexpr u8 BANK = 2;
+
   struct Track {
     u16 ntsc_tempo;
     u16 pal_tempo;

--- a/src/ggsound.hpp
+++ b/src/ggsound.hpp
@@ -54,11 +54,12 @@ namespace GGSound {
 
   // Initialize sound engine
   void init(Region region, const Track *song_list[], const Track *sfx_list[],
-            const void *instruments[],
+            const void *instruments[]
 #ifdef FEATURE_DPCM
-            const void *dpcm_pointers[],
+            ,
+            const void *dpcm_pointers[]
 #endif
-            u8 bank);
+  );
 
   // Kill all active streams and halt sound
   void stop();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,8 +61,7 @@ static void main_init() {
 
   {
     ScopedBank scopedBank(GGSound::BANK);
-    GGSound::init(GGSound::Region::NTSC, song_list, sfx_list, instrument_list,
-                  GGSound::BANK);
+    GGSound::init(GGSound::Region::NTSC, song_list, sfx_list, instrument_list);
   }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,9 +60,9 @@ static void main_init() {
   set_vram_buffer();
 
   {
-    ScopedBank scopedBank(GET_BANK(song_list));
+    ScopedBank scopedBank(GGSound::BANK);
     GGSound::init(GGSound::Region::NTSC, song_list, sfx_list, instrument_list,
-                  GET_BANK(song_list));
+                  GGSound::BANK);
   }
 }
 


### PR DESCRIPTION
They changed how ca65 addresses work (and previously we used the address to figure out the soundtrack bank... the update broke that)