### PR TITLE
Fix disabling unicorn actions during marshmallow overflow

### DIFF
--- a/src/gameplay.cpp
+++ b/src/gameplay.cpp
@@ -610,7 +610,9 @@ void Gameplay::gameplay_handler() {
   snack_was_eaten = false;
 
   if (gameplay_state == GameplayState::MarshmallowOverflow) {
-    any_pressed &= ~(PAD_START | PAD_SELECT | PAD_A | PAD_B);
+    unicorn_pressed &= ~(PAD_START | PAD_SELECT | PAD_A | PAD_B);
+    polyomino_pressed &= ~(PAD_START | PAD_SELECT | PAD_A | PAD_B);
+    any_pressed = unicorn_pressed | polyomino_pressed;
   }
 
   if (any_pressed & PAD_START) {


### PR DESCRIPTION
Fixes #203 

Code was supposed to ignore A and B button presses (which allows unicorn to push/break blocks) but it didn't.