### PR TITLE
Fix polyomino's unsigned negativish y coordinate

### DIFF
--- a/src/polyomino.cpp
+++ b/src/polyomino.cpp
@@ -350,7 +350,8 @@ void Polyomino::update(u8 drop_frames, bool &blocks_placed,
 void Polyomino::render(int y_scroll) {
   if (state != State::Active)
     return;
-  definition->render(x, y - y_scroll);
+  // XXX: extend signal if y feels negativish
+  definition->render(x, (y >= 0xe8 ? (s16)(0xff00 | y) : y) - y_scroll);
   definition->shadow(x, shadow_y - y_scroll, (u8)(shadow_row - row));
 }
 


### PR DESCRIPTION
Fixes #202 

Because polyomino `y` coordinate is stored as unsigned char, on the rare occasions it's negative it was being treated as a large positive value. To avoid doing various 16-bit operations on it, instead we just extend the sign if it "feels" negative (heuristically, y >= 0xe8)